### PR TITLE
notes on orders page commit

### DIFF
--- a/scripts/orders.js
+++ b/scripts/orders.js
@@ -34,11 +34,11 @@ const listItemsArray = (order) => {
 
     return `
         <div class="order">
-                    Order #${order.id} placed at ${new Date(order.timestamp).toLocaleString()}, has the interior seats order of ${foundInterior.type} with a ${foundTechnology.package}. You have also selected to combine that package with the extirior color of ${foundPaint.color}, and the matching ${foundWheel.type} rims.for a cost of 
+        Order #${order.id} placed at ${new Date(order.timestamp).toLocaleString()}, has the interior seats order of ${foundInterior.type} with a ${foundTechnology.package}. You have also selected to combine that package with the extirior color of ${foundPaint.color}, and the matching ${foundWheel.type} rims, all for a total cost of 
 ${totalCost.toLocaleString("en-US", {
         style: "currency",
         currency: "USD"
-    })}
+    })}.
         </div>
         `
 }


### PR DESCRIPTION
commits
The issue:  The issue was with the pop up message displaying no matter what choices were made
1. Reason for the new commit: The root cause was due to the getWheel having an uppercase case W on it, the return [...database.wheels] wasn't working correctly and causing the code to thing that it wasn't selected in the choices for the Wheels radio button
2. Solution: Corrected the code and did a check to ensure there were no other typos with capital letters and reran the code once corrected.
3.  Also updated the orders page accordingly and 
4. Added notes throughout
5. Tested and ensured it was working correctly on all browsers